### PR TITLE
(render) Fix python version key

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -43,4 +43,4 @@ services:
       - key: PORT
         value: 8000
       - key: PYTHON_VERSION
-        value: 3.12
+        value: 3.12.1


### PR DESCRIPTION
It should have major.minor.path version format